### PR TITLE
fix: empty result action list

### DIFF
--- a/mctspy/tree/search.py
+++ b/mctspy/tree/search.py
@@ -29,10 +29,12 @@ class MonteCarloTreeSearch(object):
         if simulations_number is None :
             assert(total_simulation_seconds is not None)
             end_time = time.time() + total_simulation_seconds
-            while time.time() < end_time:
+            while True:
                 v = self._tree_policy()
                 reward = v.rollout()
                 v.backpropagate(reward)
+                if time.time() > end_time:
+                    break
         else :
             for _ in range(0, simulations_number):            
                 v = self._tree_policy()


### PR DESCRIPTION
If total_simulation_seconds was set to a small enough value, due to
rounding errors, it was possible that not even one iteration of the
algo was executed and the program crashed trying to calculate the
best_child of an empty list

With this change we make sure that the progam always runs at least one
iteration